### PR TITLE
Fix CPU/GPU metrics and improve UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,10 @@
             margin:0;
             padding:0;
         }
+        .wrapper {
+            width:80%;
+            margin:0 auto;
+        }
         h1 {
             text-align:center;
             margin:20px 0;
@@ -35,27 +39,30 @@
             box-shadow:0 4px 6px rgba(0,0,0,0.4);
             user-select:none;
         }
+        .tabs li.selected {
+            background:linear-gradient(#888, #666);
+        }
         .tabs li span.ip {
             font-size:0.9em;
             color:#ddd;
             margin-left:15px;
         }
         .tab-content {
-            display:none;
             padding:20px;
             background:#555;
             border-radius:0 12px 12px 12px;
             box-shadow:0 4px 10px rgba(0,0,0,0.4);
-            width:95%;
+            width:100%;
             margin:auto;
             opacity:0;
             transform:translateX(100%);
             transition:opacity 0.5s, transform 0.5s;
+            pointer-events:none;
         }
         .tab-content.active {
-            display:block;
             opacity:1;
             transform:translateX(0);
+            pointer-events:auto;
         }
         table {
             width:60%;
@@ -66,6 +73,7 @@
         .container {
             display:flex;
             justify-content:space-between;
+            margin:15%;
         }
         .image-section {
             width:35%;
@@ -86,6 +94,7 @@
     </style>
 </head>
 <body>
+    <div class="wrapper">
     <h1>Acu.li Observe</h1>
     <ul class="tabs" id="tabs">
         {% for name, data in devices.items() %}
@@ -94,6 +103,7 @@
     </ul>
     {% for name, data in devices.items() %}
     <div class="tab-content" id="tab-{{ name }}">
+        <h2>{{ name }} <span class="ip">{{ data.ip }}</span></h2>
         <div class="container">
             <div>
                 <table>
@@ -115,14 +125,18 @@
         </div>
     </div>
     {% endfor %}
+    </div>
     <script>
         const tabs = document.querySelectorAll('.tabs li');
         const contents = document.querySelectorAll('.tab-content');
         let current = 0;
         function showTab(name){
             contents.forEach(c=>c.classList.remove('active'));
+            tabs.forEach(t=>t.classList.remove('selected'));
             document.getElementById('tab-'+name).classList.add('active');
-            current = Array.from(tabs).findIndex(t=>t.dataset.name===name);
+            const tab = Array.from(tabs).find(t=>t.dataset.name===name);
+            if(tab) tab.classList.add('selected');
+            current = Array.from(tabs).indexOf(tab);
         }
         function cycle(){
             if(tabs.length===0)return;


### PR DESCRIPTION
## Summary
- handle missing CPU2 and GPU metrics gracefully
- tweak index page margins and tab styling
- show device header inside tabs and animate selection

## Testing
- `python3 -m py_compile host.py client.py`

------
https://chatgpt.com/codex/tasks/task_e_6852a897bcc4832d824fec10cc5e5482